### PR TITLE
Fix the method getCode.

### DIFF
--- a/src/main/java/org/cts/Ellipsoid.java
+++ b/src/main/java/org/cts/Ellipsoid.java
@@ -751,7 +751,7 @@ public class Ellipsoid extends IdentifiableComponent {
         if (other instanceof Ellipsoid) {
             Ellipsoid ell = (Ellipsoid) other;
             // if ellipsoid codes are equals, ellipsoids are equals
-            if (getCode().equals(ell.getCode())) {
+            if (getAuthorityKey().equals(ell.getAuthorityKey())) {
                 return true;
             }
             // else if ellipsoid semi-major axis and ellipsoid semi-minor axis

--- a/src/main/java/org/cts/Identifier.java
+++ b/src/main/java/org/cts/Identifier.java
@@ -167,12 +167,10 @@ public class Identifier implements Identifiable {
     @Override
     public String getCode() {
         // return namespace+":"+id;
-        //Delete namespace. Consider EPSG code begin by number and IGNF code begin by decimal
-        //So code = id
         //EX: 
         //-EPSG : LAMBE
         //-IGNF : 27572
-        return authorityKey;
+        return authorityName+":"+authorityKey;
     }
 
    /**
@@ -264,14 +262,14 @@ public class Identifier implements Identifiable {
         if (object instanceof Identifier) {
             Identifier other = (Identifier)object;
             // Test equality between this code and object's code
-            if (getCode().equals(other.getCode())) {
+            if (getAuthorityKey().equals(other.getAuthorityKey())) {
                 return true;
             }
             // If not equal, test equality between this aliases and
             // the other object aliases
             for (Identifiable id1 : getAliases()) {
                 for (Identifiable id2 : other.getAliases()) {
-                    if (id1.getCode().equals(id2.getCode())) {
+                    if (id1.getAuthorityKey().equals(id2.getAuthorityKey())) {
                         return true;
                     }
                 }

--- a/src/main/java/org/cts/datum/PrimeMeridian.java
+++ b/src/main/java/org/cts/datum/PrimeMeridian.java
@@ -259,7 +259,7 @@ public class PrimeMeridian extends IdentifiableComponent {
         if (other instanceof PrimeMeridian) {
             PrimeMeridian pm = (PrimeMeridian) other;
             // if prime meridian codes or names are equals, return true
-            if (getCode().equals(pm.getCode())
+            if (getAuthorityKey().equals(pm.getAuthorityKey())
                     || getName().equalsIgnoreCase(pm.getName())) {
                 return true;
             }


### PR DESCRIPTION
The function getAuthorityKey and getCode are no longer redundant.
getCode now returns authorityName:authorityKey,
and it has been replaced by method getAuthorityKey() in functions that used it.
