### PR TITLE
Add trim in prj parser

### DIFF
--- a/src/main/java/org/cts/parser/prj/PrjMatcher.java
+++ b/src/main/java/org/cts/parser/prj/PrjMatcher.java
@@ -330,7 +330,7 @@ public final class PrjMatcher {
     private void parseString(PrjElement e, String name) {
         if (e instanceof PrjStringElement) {
             PrjStringElement s = (PrjStringElement) e;
-            params.put(name, s.getValue());
+            params.put(name, s.getValue().trim());
         } else {
             throw new PrjParserException("Failed to parse PRJ. Found '" + e + "', expected PrjStringElement with " + name + " in it.");
         }
@@ -339,7 +339,7 @@ public final class PrjMatcher {
     private String getString(PrjElement e) {
         if (e instanceof PrjStringElement) {
             PrjStringElement s = (PrjStringElement) e;
-            return s.getValue();
+            return s.getValue().trim();
         }
         throw new PrjParserException("Failed to parse PRJ. Found '" + e + "', expected some PrjStringElement.");
     }

--- a/src/test/java/org/cts/CRSFactoryTest.java
+++ b/src/test/java/org/cts/CRSFactoryTest.java
@@ -91,4 +91,23 @@ public class CRSFactoryTest {
         assertTrue(crs.getAuthorityKey().equals("27572"));
     }
     
+    @Test
+    public void testOGC_WKT_27572_CRS_SPACE(){
+        String prj = "PROJCS[\" NTF (Paris) / Lambert zone II \",GEOGCS[\" NTF (Paris) \","
+                + "DATUM[\" Nouvelle_Triangulation_Francaise_Paris \","
+                + "SPHEROID[\" Clarke 1880 (IGN) \", 6378249.2 , 293.4660212936269 ,"
+                + "AUTHORITY[\" EPSG \" , \" 7011 \"]],TOWGS84[ -168 , -60 , 320 , 0 , 0 , 0 , 0 ],"
+                + "AUTHORITY[\" EPSG \" , \" 6807 \"]],PRIMEM[\" Paris \", 2.33722917 ,"
+                + "AUTHORITY[\" EPSG \" , \" 8903 \"]],UNIT[\" grad \", 0.01570796326794897 ,"
+                + "AUTHORITY[\" EPSG \" , \" 9105 \"]],AUTHORITY[\" EPSG \",\" 4807 \"]],UNIT[\" metre \" , 1 , "
+                + "AUTHORITY[\" EPSG \" , \" 9001 \"]],PROJECTION[\" Lambert_Conformal_Conic_1SP \"],"
+                + "PARAMETER[\" latitude_of_origin \" , 52 ],PARAMETER[\" central_meridian \" , 0 ],"
+                + "PARAMETER[\" scale_factor \" , 0.99987742 ],PARAMETER[\" false_easting \" , 600000 ],"
+                + "PARAMETER[\" false_northing \" , 2200000 ],"
+                + "AUTHORITY[\" EPSG \" , \" 27572 \"],AXIS[\" X \" , EAST ],AXIS[\" Y \" , NORTH ]] ";
+        CoordinateReferenceSystem crs = cRSFactory.createFromPrj(prj);
+        assertNotNull(crs);
+        assertTrue(crs.getAuthorityName().equals("EPSG"));
+        assertTrue(crs.getAuthorityKey().equals("27572"));
+    }
 }


### PR DESCRIPTION
Add trim in prj parser to prevent errors from unexpected leading and trailing whitespace.
