### PR TITLE
A workaround to prevent a bad prj OGC WKT 

### DIFF
--- a/src/main/java/org/cts/parser/prj/PrjMatcher.java
+++ b/src/main/java/org/cts/parser/prj/PrjMatcher.java
@@ -788,7 +788,14 @@ public final class PrjMatcher {
      */
     private String getAuthority(List<PrjElement> ll) {
         String auth = getString(ll.get(0));
-        String code = getString(ll.get(1));
+        PrjElement authorityCode = ll.get(1);
+        String code ;
+        if(authorityCode instanceof PrjNumberElement){
+            code =  String.valueOf(Math.round(getNumber(authorityCode)));            
+        }
+        else{
+            code = getString(authorityCode);
+        }
         return auth + ':' + code;
     }
 

--- a/src/test/java/org/cts/parser/prj/PrjParserTest.java
+++ b/src/test/java/org/cts/parser/prj/PrjParserTest.java
@@ -263,4 +263,14 @@ public class PrjParserTest {
         assertNotNull(crs);
         assertTrue(crs instanceof GeocentricCRS);
     }
+
+    @Test
+    public void testCH1903_LV03_PRJ() throws Exception {
+        String prj = "PROJCS[\"CH1903_LV03\",GEOGCS[\"GCS_CH1903\",DATUM[\"D_CH1903\","
+                + "SPHEROID[\"Bessel_1841\",6377397.155,299.1528128]],PRIMEM[\"Greenwich\",0.0],"
+                + "UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Hotine_Oblique_Mercator_Azimuth_Center\"],PARAMETER[\"False_Easting\",600000.0],PARAMETER[\"False_Northing\",200000.0],PARAMETER[\"Scale_Factor\",1.0],PARAMETER[\"Azimuth\",90.0],"
+                + "PARAMETER[\"Longitude_Of_Center\",7.439583333333333],PARAMETER[\"Latitude_Of_Center\",46.95240555555556],UNIT[\"Meter\",1.0],AUTHORITY[\"EPSG\",21781]]";
+        Map<String, String> p = parser.getParameters(prj);
+        assertTrue(p.get(PrjKeyParameters.REFNAME).equals("EPSG:21781"));
+    }
 }


### PR DESCRIPTION
Sometimes the code authory can be a integer even if the OGC WKT standard needs a string.

An example has been founded from swiss projection.
eg : "EPSG":21781 must be "EPSG":"21781".
