### PR TITLE
pom.xml update with explicit Java version and upgraded versions of plugins and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
   </build>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>        
   </properties>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,15 +37,17 @@
   <build>
     <plugins>
       <plugin>
+      	<!-- https://mvnrepository.com/artifact/org.apache.felix/maven-bundle-plugin -->
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
+        <version>3.5.0</version>
         <extensions>true</extensions>
       </plugin>
       <plugin>
+        <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.15</version>
+        <version>2.21.0</version>
       </plugin>
     </plugins>
   </build>
@@ -56,15 +58,17 @@
   </properties>
   <dependencies>
     <dependency>
+      <!-- https://mvnrepository.com/artifact/junit/junit -->
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.10</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
+      <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.6.0</version>
+      <version>1.7.25</version>
     </dependency>
     <!-- Remove comment to see Unit Test log messages
     <dependency>


### PR DESCRIPTION
I added java version in pom.xml because I got the following compilation error (when running Windows 10 with JDK 9.0.4 and Maven 3.5.3):
Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.6.1:compile (default-compile) on project cts: Compilation failure: Compilation failure:
[ERROR] Source option 1.5 is no longer supported. Use 1.6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.

Also added later versions of plugins and dependencies in the pom file.
All 240 tests are still succeeding after these changes.