### PR TITLE
Fix ticket #112 (add toWGS84 transform TM65 datum)

### DIFF
--- a/src/main/java/org/cts/datum/GeodeticDatum.java
+++ b/src/main/java/org/cts/datum/GeodeticDatum.java
@@ -252,7 +252,7 @@ public class GeodeticDatum extends AbstractDatum {
     
     public final static GeodeticDatum HERMANNSKOGEL = new GeodeticDatum(
             new Identifier("EPSG", "4312", "Militar-Geographische Institut", "MGI"),
-            PrimeMeridian.GREENWICH, Ellipsoid.BESSEL1841,null, 
+            PrimeMeridian.GREENWICH, Ellipsoid.BESSEL1841, null,
             new GeographicExtent("Austria", 46.4, 49.02, 9.53, 17.17), "","" );
     
     public final static GeodeticDatum POSTDAM = new GeodeticDatum(
@@ -281,7 +281,8 @@ public class GeodeticDatum extends AbstractDatum {
     
     public final static GeodeticDatum IRE65 = new GeodeticDatum(
             new Identifier("EPSG", "4299", "TM65", "TM65"),
-            PrimeMeridian.GREENWICH, Ellipsoid.AIRYMOD, null,
+            PrimeMeridian.GREENWICH, Ellipsoid.AIRYMOD,
+            SevenParameterTransformation.createBursaWolfTransformation(482.5, -130.6, 564.6, -1.042, -0.214, -0.631, 8.15, 1),
             new GeographicExtent("Ireland - onshore. United Kingdom (UK) - Northern Ireland (Ulster) - onshore",
                     51.39, 55.43, -10.56, -5.34), "", "");
  

--- a/src/test/java/org/cts/op/BatchCoordinateTransformTest.java
+++ b/src/test/java/org/cts/op/BatchCoordinateTransformTest.java
@@ -75,8 +75,8 @@ public class BatchCoordinateTransformTest extends BaseCoordinateTransformTest {
             double[] result = transform((GeodeticCRS) inputCRS, (GeodeticCRS) outputCRS, pointSource);
             double[] pointDest = new double[]{csNameDest_X, csNameDest_Y};
             double[] check = transform((GeodeticCRS) outputCRS, (GeodeticCRS) inputCRS, pointDest);
-            assertTrue(checkEquals2D(id + " dir--> " + csNameSrc + " to " + csNameDest, result, pointDest, tolerance));
-            assertTrue(checkEquals2D(id + " inv--> " + csNameDest + " to " + csNameSrc, check, pointSource, 0.01));           
+            assertTrue(checkEquals2D(id + " dir--> " + csNameSrc + " to " + csNameDest, result, pointDest, tolerance), "Error for direct transformation line " + line + "\n");
+            assertTrue(checkEquals2D(id + " inv--> " + csNameDest + " to " + csNameSrc, check, pointSource, 0.01), "Error for inverse transformation line " + line + "\n");
         }
         lineReader.close();
     }


### PR DESCRIPTION
This PR should fix #112 (test 49, 52, 54 using TM65 datum)
but last epsg registry update introduced at least two regressions
test 14 : towgs84 parameters changed. It is no more the same as those published by IGN for ED50
test 41 : there has also been a change in 2065 definition, maybe related to https://github.com/OSGeo/proj.4/issues/185