### PR TITLE
Fix ticket #96 add Extent to CRS

### DIFF
--- a/src/main/java/org/cts/crs/CoordinateReferenceSystem.java
+++ b/src/main/java/org/cts/crs/CoordinateReferenceSystem.java
@@ -25,6 +25,7 @@ package org.cts.crs;
 
 import org.cts.Identifiable;
 import org.cts.cs.CoordinateSystem;
+import org.cts.cs.Extent;
 import org.cts.datum.Datum;
 import org.cts.op.projection.Projection;
 
@@ -47,50 +48,54 @@ import org.cts.op.projection.Projection;
  *
  * @author Michaël Michaud
  */
-public interface CoordinateReferenceSystem extends Identifiable {
+public interface CoordinateReferenceSystem extends Identifiable, Extent {
 
     /**
      * Coordinate Reference System Type.
      */
-    public enum Type {
+    enum Type {
 
         GEOCENTRIC, GEOGRAPHIC3D, GEOGRAPHIC2D, PROJECTED, VERTICAL, COMPOUND, ENGINEERING
     }
 
     /**
-     * Returns this CoordinateReferenceSystem Type.
-     * @return 
+     * Returns this <code>CoordinateReferenceSystem.Type</code>.
      */
-    public Type getType();
+    Type getType();
 
     /**
      * Returns the {@link CoordinateSystem} used by this
      * <code>CoordinateReferenceSystem</code>.
-     * @return 
      */
-    public CoordinateSystem getCoordinateSystem();
+    CoordinateSystem getCoordinateSystem();
 
     /**
      * Returns the {@link Datum} to which this
-     * <code>CoordinateReferenceSystem</code> is refering. For compound
-     * <code>CoordinateReferenceSystem</code>, getDatum returns the the main
-     * datum, ie the {@link org.cts.datum.GeodeticDatum} (or horizontal Datum).
-     * @return 
+     * <code>CoordinateReferenceSystem</code> refers.
+     * For compound <code>CoordinateReferenceSystem</code>, getDatum returns the
+     * main datum, ie the {@link org.cts.datum.GeodeticDatum} (or horizontal Datum).
      */
-    public Datum getDatum();
+    Datum getDatum();
 
     /**
      * Returns the {@link Projection} to which this
-     * <code>CoordinateReferenceSystem</code> is refering. It returns null if no
+     * <code>CoordinateReferenceSystem</code> refers. It returns null if no
      * projection is defined for this CRS.
-     * @return 
+     * @return the {@link Projection} used by this
+     * <code>CoordinateReferenceSystem</code> or null.
      */
-    public Projection getProjection();
+    Projection getProjection();
 
     /**
-     * Returns a WKT representation of the CoordinateReferenceSystem.
-     *
-     * @return 
+     * Returns a WKT representation of this <code>CoordinateReferenceSystem</code>.
      */
-    public String toWKT();
+    String toWKT();
+
+    /**
+     * Returns whether coord is inside this Extent or not. It's up to the user to
+     * check consistency between coord and extent type.
+     */
+    default boolean isInside(double[] coord) {
+        return true;
+    }
 }

--- a/src/main/java/org/cts/crs/GeocentricCRS.java
+++ b/src/main/java/org/cts/crs/GeocentricCRS.java
@@ -56,11 +56,11 @@ public class GeocentricCRS extends GeodeticCRS {
     /**
      * A 3D cartesian {@link CoordinateSystem}.
      */
-    public static final CoordinateSystem XYZ = new CoordinateSystem(new Axis[]{X, Y, Z}, new Unit[]{METER, METER, METER});
+    public static final CoordinateSystem XYZ =
+            new CoordinateSystem(new Axis[]{X, Y, Z}, new Unit[]{METER, METER, METER});
 
     /**
-     * Returns this CoordinateReferenceSystem Type.
-     * @return 
+     * @see CoordinateReferenceSystem#getType().
      */
     @Override
     public Type getType() {
@@ -92,12 +92,14 @@ public class GeocentricCRS extends GeodeticCRS {
     }
 
     /**
-     * @return 
+     * Creates a CoordinateOperation to transform coordinates from this
+     * <code>GeocentricCRS</code> to the associated <code>Geographic3DCRS</code>.
+     *
      * @see GeodeticCRS#toGeographicCoordinateConverter()
      */
     @Override
     public CoordinateOperation toGeographicCoordinateConverter() {
-        List<CoordinateOperation> ops = new ArrayList<CoordinateOperation>();
+        List<CoordinateOperation> ops = new ArrayList<>();
         ops.add(new Geocentric2Geographic(getDatum().getEllipsoid()));
         if (!getDatum().getPrimeMeridian().equals(PrimeMeridian.GREENWICH)) {
             ops.add(LongitudeRotation.getLongitudeRotationTo(getDatum().getPrimeMeridian()));
@@ -107,12 +109,14 @@ public class GeocentricCRS extends GeodeticCRS {
     }
 
     /**
-     * @return 
+     * Creates a CoordinateOperation to transform coordinates from the associated
+     * <code>Geographic3DCRS</code> to this <code>GeocentricCRS</code>.
+     *
      * @see GeodeticCRS#fromGeographicCoordinateConverter()
      */
     @Override
     public CoordinateOperation fromGeographicCoordinateConverter() {
-        List<CoordinateOperation> ops = new ArrayList<CoordinateOperation>();
+        List<CoordinateOperation> ops = new ArrayList<>();
         if (!getDatum().getPrimeMeridian().equals(PrimeMeridian.GREENWICH)) {
             ops.add(LongitudeRotation.getLongitudeRotationFrom(getDatum().getPrimeMeridian()));
         }
@@ -122,9 +126,7 @@ public class GeocentricCRS extends GeodeticCRS {
     }
 
     /**
-     * Returns a WKT representation of the geocentric CRS.
-     *
-     * @return 
+     * @see CoordinateReferenceSystem#toWKT()
      */
     public String toWKT() {
         StringBuilder w = new StringBuilder();

--- a/src/main/java/org/cts/cs/Extent.java
+++ b/src/main/java/org/cts/cs/Extent.java
@@ -37,11 +37,11 @@ public interface Extent {
     /**
      * Return the name of this extent.
      */
-    public String getName();
+    String getName();
 
     /**
-     * Return wether coord is inside this Extent or not. It's up to the user to
+     * Returns wether coord is inside this Extent or not. It's up to the user to
      * check consistency between coord and extent type.
      */
-    public boolean isInside(double[] coord);
+    boolean isInside(double[] coord);
 }

--- a/src/main/java/org/cts/op/CheckInExtentCoordinateOperation.java
+++ b/src/main/java/org/cts/op/CheckInExtentCoordinateOperation.java
@@ -1,0 +1,67 @@
+package org.cts.op;
+
+import org.cts.Identifier;
+import org.cts.IllegalCoordinateException;
+import org.cts.crs.CoordinateReferenceSystem;
+import org.cts.cs.Extent;
+
+import java.util.Arrays;
+
+
+public class CheckInExtentCoordinateOperation extends AbstractCoordinateOperation {
+
+    Extent extent;
+
+    public CheckInExtentCoordinateOperation(CoordinateReferenceSystem crs) {
+        super(new Identifier(CoordinateOperation.class, "extent of '" + crs.getName() + "'"));
+        this.extent = crs;
+    }
+
+    /**
+     * Check if coord lies in extent. If it is inside, coord is returned as is,
+     * else, a IllegalCoordinateException is thrown.
+     *
+     * @param coord coordinate to check
+     * @return the same coordinates array
+     * @throws IllegalCoordinateException if <code>coord</code> does not lie in extent.
+     * @throws org.cts.op.CoordinateOperationException if this operation
+     * failed during the transformation process.
+     */
+    public double[] transform(double[] coord) throws IllegalCoordinateException {
+        if (extent == null || extent.isInside(coord)) return coord;
+        throw new IllegalCoordinateException("Coord " + Arrays.toString(coord) + " is not within " + getName());
+    }
+
+    /**
+     * Return the inverse CoordinateOperation, or throw a
+     * NonInvertibleOperationException. If op.inverse() is not null,
+     * <pre>
+     * op.inverse().transform(op.transform(point));
+     * </pre> should let point unchanged.
+     */
+    public CoordinateOperation inverse() {
+        return this;
+    }
+
+    ///**
+    // * Returns the maximum precision
+    // */
+    //public double getPrecision() {
+    //    return 1E-9;
+    //}
+
+    ///**
+    // * @return true if this operation does not change coordinates.
+    // */
+    //public boolean isIdentity() {
+    //    return true;
+    //}
+
+    /**
+     * Returns whether coord is consistent with source and target CRS.
+     */
+    //public boolean isInside(double[] coord) {
+    //    if (extent == null || extent.isInside(coord)) return true;
+    //    throw new IllegalCoordinateException("Coordinates " + coord + " does not lie in extent");
+    //}
+}

--- a/src/main/java/org/cts/op/CoordinateOperation.java
+++ b/src/main/java/org/cts/op/CoordinateOperation.java
@@ -49,7 +49,7 @@ public interface CoordinateOperation extends Identifiable {
      * @throws org.cts.op.CoordinateOperationException if this operation
      * failed during the transformation process.
      */
-    public double[] transform(double[] coord) throws IllegalCoordinateException, CoordinateOperationException;
+    double[] transform(double[] coord) throws IllegalCoordinateException, CoordinateOperationException;
 
     /**
      * Return the inverse CoordinateOperation, or throw a
@@ -58,7 +58,7 @@ public interface CoordinateOperation extends Identifiable {
      * op.inverse().transform(op.transform(point));
      * </pre> should let point unchanged.
      */
-    public CoordinateOperation inverse() throws NonInvertibleOperationException;
+    CoordinateOperation inverse() throws NonInvertibleOperationException;
 
     /**
      * Return the precision of the transformation.<p> Precision is a double
@@ -70,10 +70,10 @@ public interface CoordinateOperation extends Identifiable {
      * value of an ulp (units in the last place) for a double value equals to
      * 6378137.0 (Earth semi-major axis).
      */
-    public double getPrecision();
+    double getPrecision();
 
     /**
      * @return true if this operation does not change coordinates.
      */
-    public boolean isIdentity();
+    boolean isIdentity();
 }

--- a/src/main/java/org/cts/op/CoordinateOperationFactory.java
+++ b/src/main/java/org/cts/op/CoordinateOperationFactory.java
@@ -60,8 +60,9 @@ public final class CoordinateOperationFactory {
      *
      * @param source the (non null) source geodetic coordinate reference system
      * @param target the (non null) target geodetic coordinate reference system
-     * @return 
-     * @throws org.cts.op.CoordinateOperationException 
+     *
+     * @throws org.cts.op.CoordinateOperationException if an Exception occurs during the
+     * CoordinateOperation computation.
      */
     public static Set<CoordinateOperation> createCoordinateOperations(
             GeodeticCRS source, GeodeticCRS target) throws CoordinateOperationException {
@@ -71,7 +72,7 @@ public final class CoordinateOperationFactory {
         if (target == null) {
             throw new IllegalArgumentException("The target CRS must not be null");
         }
-        Set<CoordinateOperation> opList = new HashSet<CoordinateOperation>();
+        Set<CoordinateOperation> opList = new HashSet<>();
         GeodeticDatum sourceDatum = source.getDatum();
         if (sourceDatum == null) {
             LOG.warn(source.getName() + " has no Geodetic Datum");
@@ -149,7 +150,7 @@ public final class CoordinateOperationFactory {
 
         // We get registered transformation from source GeodeticDatum to target GeodeticDatum
         // There maybe more than one transformations available.
-        Set<CoordinateOperation> datumTransformations = new HashSet<CoordinateOperation>(2);
+        Set<CoordinateOperation> datumTransformations = new HashSet<>(2);
 
         // If source CRS or target CRS is 3D, we need to use a 3D Geocentric transformation
         // from source Datum to target Datum
@@ -184,6 +185,7 @@ public final class CoordinateOperationFactory {
                         GeocentricTransformationSequence newSequence = new GeocentricTransformationSequence(
                                 new Identifier(CoordinateOperation.class,
                                         source.getCode() + " to " + target.getCode() + " through " + datumTransformation.getName()),
+                                new CheckInExtentCoordinateOperation(source),
                                 source.toGeographicCoordinateConverter(),
                                 new LongitudeRotation(source.getDatum().getPrimeMeridian().getLongitudeFromGreenwichInRadians()),
                                 new Geographic2Geocentric(source.getDatum().getEllipsoid()),
@@ -224,6 +226,7 @@ public final class CoordinateOperationFactory {
                         opList.add(new CoordinateOperationSequence(
                                 new Identifier(CoordinateOperationSequence.class,
                                 source.getCode() + " to " + target.getCode() + " through " + datumTf.getName()),
+                                new CheckInExtentCoordinateOperation(source),
                                 source.toGeographicCoordinateConverter(),
                                 datumTf,
                                 target.fromGeographicCoordinateConverter()));
@@ -241,9 +244,12 @@ public final class CoordinateOperationFactory {
 
     /**
      * Returns {@link org.cts.op.CoordinateOperation}s including operations of a particular type.
+     * @param ops a collection of CoordinateOperation
+     * @param clazz include CoordinateOperations of this class
      */
-    public static Set<CoordinateOperation> includeFilter(Collection<? extends CoordinateOperation> ops, Class clazz) {
-        Set<CoordinateOperation> list = new HashSet<CoordinateOperation>();
+    public static Set<CoordinateOperation> includeFilter(Collection<? extends CoordinateOperation> ops,
+                                                         Class<? extends CoordinateOperation> clazz) {
+        Set<CoordinateOperation> list = new HashSet<>();
         for (CoordinateOperation op : ops) {
             if (clazz.isAssignableFrom(op.getClass())) list.add(op);
             else if (op instanceof CoordinateOperationSequence) {
@@ -262,12 +268,12 @@ public final class CoordinateOperationFactory {
 
     /**
      * Returns {@link org.cts.op.CoordinateOperation}s excluding sequence containing a particular operation type.
-     * @param ops
-     * @param clazz
-     * @return 
+     * @param ops a collection of CoordinateOperation
+     * @param clazz exlude CoordinateOperations of this class
      */
-    public static Set<CoordinateOperation> excludeFilter(Collection<? extends CoordinateOperation> ops, Class clazz) {
-        Set<CoordinateOperation> list = new HashSet<CoordinateOperation>();
+    public static Set<CoordinateOperation> excludeFilter(Collection<? extends CoordinateOperation> ops,
+                                                         Class<? extends CoordinateOperation> clazz) {
+        Set<CoordinateOperation> list = new HashSet<>();
         for (CoordinateOperation op : ops) {
             if (clazz.isAssignableFrom(op.getClass())) continue;
             if (op instanceof CoordinateOperationSequence) {
@@ -286,8 +292,7 @@ public final class CoordinateOperationFactory {
 
     /**
      * Returns the most precise among the list of {@link org.cts.op.CoordinateOperation}s.
-     * @param ops
-     * @return 
+     * @param ops a collection of CoordinateOperation
      */
     public static CoordinateOperation getMostPrecise(Collection<? extends CoordinateOperation> ops) {
         CoordinateOperation preciseOp = null;
@@ -303,8 +308,7 @@ public final class CoordinateOperationFactory {
 
     /**
      * Returns the most precise among the list of {@link org.cts.op.CoordinateOperation}s.
-     * @param ops
-     * @return 
+     * @param ops a collection of CoordinateOperation
      */
     public static CoordinateOperation getMostPrecise3DTransformation(Collection<? extends CoordinateOperation> ops) {
         CoordinateOperation preciseOp = null;

--- a/src/main/java/org/cts/op/transformation/GridBasedTransformation.java
+++ b/src/main/java/org/cts/op/transformation/GridBasedTransformation.java
@@ -23,10 +23,13 @@
  */
 package org.cts.op.transformation;
 
+import org.cts.op.CoordinateOperation;
+
 /**
  * Marker for transformation based on grids like NTv2 or
  * vertical transformations
  * @author Michaël Michaud
  */
-public interface GridBasedTransformation {
+public interface GridBasedTransformation extends CoordinateOperation {
+
 }

--- a/src/test/java/org/cts/op/CheckCRSExtentTest.java
+++ b/src/test/java/org/cts/op/CheckCRSExtentTest.java
@@ -1,0 +1,102 @@
+package org.cts.op;
+
+import org.cts.CRSFactory;
+import org.cts.IllegalCoordinateException;
+import org.cts.crs.CRSException;
+import org.cts.crs.GeodeticCRS;
+import org.cts.registry.EPSGRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class CheckCRSExtentTest {
+
+    // Lambert 93 (2154)
+    // Projected bounds:
+    // -378305.81 6093283.21
+    // 1212610.74 7186901.68
+    // WGS84 bounds:
+    // -9.86 41.15
+    // 10.38 51.56
+    @Test
+    void testExtentInLocalCRS() throws CRSException, CoordinateOperationException, IllegalCoordinateException {
+        CRSFactory crsFactory = new CRSFactory();
+        crsFactory.getRegistryManager().addRegistry(new EPSGRegistry());
+        GeodeticCRS crs1 = (GeodeticCRS) crsFactory.getCRS("EPSG:2154");
+        GeodeticCRS crs2 = (GeodeticCRS) crsFactory.getCRS("EPSG:4326");
+        CoordinateOperation op = CoordinateOperationFactory.createCoordinateOperations(crs1, crs2).iterator().next();
+        crs1.setExtent(new double[]{-378305.81, 6093283.21}, new double[]{1212610.74,7186901.68});
+        System.out.println(Arrays.toString(op.transform(new double[]{0.0, 7000000.0})));
+        assertTrue(true);
+    }
+
+    @Test
+    void testExtentInGeographicCRS() throws CRSException, CoordinateOperationException, IllegalCoordinateException {
+        CRSFactory crsFactory = new CRSFactory();
+        crsFactory.getRegistryManager().addRegistry(new EPSGRegistry());
+        GeodeticCRS crs1 = (GeodeticCRS) crsFactory.getCRS("EPSG:2154");
+        GeodeticCRS crs2 = (GeodeticCRS) crsFactory.getCRS("EPSG:4326");
+        CoordinateOperation op = CoordinateOperationFactory.createCoordinateOperations(crs1, crs2).iterator().next();
+        //crs1.setExtent(new double[]{-378305.81, 6093283.21}, new double[]{1212610.74,7186901.68});
+        crs1.setExtent(-9.86, 41.15, 10.38, 51.56);
+        System.out.println(Arrays.toString(op.transform(new double[]{0.0, 7000000.0})));
+        assertTrue(true);
+    }
+
+    @Test
+    void testExtentNotInLocalCRS() throws CRSException, CoordinateOperationException, IllegalCoordinateException, IOException {
+        CRSFactory crsFactory = new CRSFactory();
+        crsFactory.getRegistryManager().addRegistry(new EPSGRegistry());
+        GeodeticCRS crs1 = (GeodeticCRS) crsFactory.getCRS("EPSG:2154");
+        GeodeticCRS crs2 = (GeodeticCRS) crsFactory.getCRS("EPSG:4326");
+        CoordinateOperation op = CoordinateOperationFactory.createCoordinateOperations(crs1, crs2).iterator().next();
+        crs1.setExtent(new double[]{-378305.81, 6093283.21}, new double[]{1212610.74,7186901.68});
+        Exception exception = assertThrows(IllegalCoordinateException.class, () -> {
+            System.out.println(Arrays.toString(op.transform(new double[]{-400000.0, 7000000.0})));
+        });
+    }
+
+    @Test
+    void testExtentNotInGeographicCRS() throws CRSException, CoordinateOperationException, IllegalCoordinateException {
+        CRSFactory crsFactory = new CRSFactory();
+        crsFactory.getRegistryManager().addRegistry(new EPSGRegistry());
+        GeodeticCRS crs1 = (GeodeticCRS) crsFactory.getCRS("EPSG:2154");
+        GeodeticCRS crs2 = (GeodeticCRS) crsFactory.getCRS("EPSG:4326");
+        CoordinateOperation op = CoordinateOperationFactory.createCoordinateOperations(crs1, crs2).iterator().next();
+        //crs1.setExtent(new double[]{-378305.81, 6093283.21}, new double[]{1212610.74,7186901.68});
+        crs1.setExtent(-9.86, 41.15, 10.38, 51.56);
+        Exception exception = assertThrows(IllegalCoordinateException.class, () -> {
+            System.out.println(Arrays.toString(op.transform(new double[]{-400000.0, 7000000.0})));
+        });
+    }
+
+    @Test
+    void testExtentInWGSCRS() throws CRSException, CoordinateOperationException, IllegalCoordinateException, IOException {
+        CRSFactory crsFactory = new CRSFactory();
+        crsFactory.getRegistryManager().addRegistry(new EPSGRegistry());
+        GeodeticCRS crs1 = (GeodeticCRS) crsFactory.getCRS("EPSG:2154");
+        GeodeticCRS crs2 = (GeodeticCRS) crsFactory.getCRS("EPSG:4326");
+        CoordinateOperation op = CoordinateOperationFactory.createCoordinateOperations(crs2, crs1).iterator().next();
+        crs2.setExtent(-9.86, 41.15, 10.38, 51.56);
+        System.out.println(Arrays.toString(op.transform(new double[]{1.0, 45.0})));
+        assertTrue(true);
+    }
+
+    @Test
+    void testExtentNotInWGSCRS() throws CRSException, CoordinateOperationException, IllegalCoordinateException, IOException {
+        CRSFactory crsFactory = new CRSFactory();
+        crsFactory.getRegistryManager().addRegistry(new EPSGRegistry());
+        GeodeticCRS crs1 = (GeodeticCRS) crsFactory.getCRS("EPSG:2154");
+        GeodeticCRS crs2 = (GeodeticCRS) crsFactory.getCRS("EPSG:4326");
+        CoordinateOperation op = CoordinateOperationFactory.createCoordinateOperations(crs2, crs1).iterator().next();
+        crs2.setExtent(-9.86, 41.15, 10.38, 51.56);
+        Exception exception = assertThrows(IllegalCoordinateException.class, () -> {
+            System.out.println(Arrays.toString(op.transform(new double[]{-10.0, 45.0})));
+        });
+    }
+}


### PR DESCRIPTION
Proposition to add extent to CRS.
As Extent is an interface, I just implemented it in CoordinateReferenceSystem. Default implementation always return true. GeodeticCRS implementation makes it possible to define Extent from projected coordinates or from geographic coordinates (referring to this CRS's Datum).  In the later case, geographic coordinates are transformed into this CRS's coordinates.
Needs more tests.