### PR TITLE
Use junit-jupiter-api in test scope only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit-version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Having it as a runtime dependency increases the bundle size unnecessarily and may break downstream tests if they depend on cts and also use an incompatible junit version.

Error message when running `mvn clean test`  in the depending project:
```
TestEngine with ID 'junit-jupiter' failed to discover tests
```

The issue can be mitigated by adding a `<exclusion>` tag to the respective dependency declaration, but simply correcting the scope solves the issue for all users of CTS.

```xml
        <dependency>
            <groupId>org.orbisgis</groupId>
            <artifactId>cts</artifactId>
            <version>1.7.1</version>
            <exclusions>
                <exclusion>
                    <groupId>org.junit.jupiter</groupId>
                    <artifactId>junit-jupiter-api</artifactId>
                </exclusion>
            </exclusions>
        </dependency>
```

Thanks for your great work!